### PR TITLE
Prevent patient out of fence email spam.

### DIFF
--- a/models/patient.js
+++ b/models/patient.js
@@ -21,7 +21,8 @@
       token : { type: String },
       email : { type: String, limit: 150 },
       name: { type: String, limit: 50 },
-      carer_id: {type: String}
+      carer_id: {type: String},
+      last_outside: {type: Boolean, default: false}
     });
 
     var Location = schemaMongo.define('Location', {

--- a/routes/api/patient.js
+++ b/routes/api/patient.js
@@ -143,18 +143,20 @@
                   if(outsideAll) {
                     // Send an email to the carer as they are outside an outer (carer notify) fence
                     //console.log("OUTSIDE ALL - ALERT THE CARER");
-                    carerModel.find(data.carer_id, function(err, carer) {
-                      if (carer && !data.last_outside) {
-                        var recipient = carer.email;
-                        var subject = "Fence Notification - " + data.name;
-                        var message = data.name + " is outside the virtual fences set for them.\n" +
-                                  "Location: " + req.body.latitude + ", " + req.body.longitude +
-                                  "\nTime: " + datefmts.asString('dd/MM/yyyy hh:mm', new Date());
+                    if (!data.last_outside) {
+                      carerModel.find(data.carer_id, function(err, carer) {
+                        if (carer) {
+                          var recipient = carer.email;
+                          var subject = "Fence Notification - " + data.name;
+                          var message = data.name + " is outside the virtual fences set for them.\n" +
+                                    "Location: " + req.body.latitude + ", " + req.body.longitude +
+                                    "\nTime: " + datefmts.asString('dd/MM/yyyy hh:mm', new Date());
 
-                        sendMail(recipient, subject, message);
-                        data.updateAttribute('last_outside', true);
-                      }
-                    });
+                          sendMail(recipient, subject, message);
+                          data.updateAttribute('last_outside', true);
+                        }
+                      });
+                    }
 
                   }
                 }

--- a/routes/api/patient.js
+++ b/routes/api/patient.js
@@ -137,14 +137,14 @@
 
                 if(outsideAllInner) {
                   // Send push notification to phone as they are outside a fence
-                  console.log("OUTSIDE ALL INNER FENCES - ALERT THE PATIENT");
+                  //console.log("OUTSIDE ALL INNER FENCES - ALERT THE PATIENT");
                   //perhaps set a variable here, and attach it to the json returned
 
                   if(outsideAll) {
                     // Send an email to the carer as they are outside an outer (carer notify) fence
-                    console.log("OUTSIDE ALL - ALERT THE CARER");
+                    //console.log("OUTSIDE ALL - ALERT THE CARER");
                     carerModel.find(data.carer_id, function(err, carer) {
-                      if (carer) {
+                      if (carer && !data.last_outside) {
                         var recipient = carer.email;
                         var subject = "Fence Notification - " + data.name;
                         var message = data.name + " is outside the virtual fences set for them.\n" +
@@ -152,9 +152,15 @@
                                   "\nTime: " + datefmts.asString('dd/MM/yyyy hh:mm', new Date());
 
                         sendMail(recipient, subject, message);
+                        data.updateAttribute('last_outside', true);
                       }
                     });
+
                   }
+                }
+
+                if (!outsideAll || !outsideAllInner) {
+                  data.updateAttribute('last_outside', false);
                 }
               });
             }


### PR DESCRIPTION
Only emails the carer once when the patient crosses the fence, rather than every location post outside the fence. A patient entering a fence again will reset this, meaning the carer will be notified by email if the patient crosses the fence again.
