### PR TITLE
Removed patient_id arrays from Carer

### DIFF
--- a/models/carer.js
+++ b/models/carer.js
@@ -23,8 +23,7 @@
       email :           { type: String, limit: 150 },
       name:             { type: String, limit: 50 },
       address:          { type: String },
-      contact_number:   { type: String },
-      patientsIds:      []
+      contact_number:   { type: String }
     });
 
     Carer.hasMany(Patient, {as: 'patients', foreignKey: 'carer_id'});

--- a/public/js/controllers/patients.js
+++ b/public/js/controllers/patients.js
@@ -68,8 +68,9 @@
     };
 
     self.addPatientToCarerRelationsship = function () {
+        console.log("Adding patient");
         Carer.updateRelation({carerId:$scope.carer.id, patientId:$scope.newPatient.id}, function(message){
-          updateCarerPatientsList();
+          refreshCarerPatientsList();
           $scope.newPatient.id = null;
         });
       };
@@ -94,6 +95,7 @@
     };
 
     var refreshCarerPatientsList = function(){
+      console.log("Refreshing patients");
       Patient.getCarersPatients({id:$scope.carer.id}, function(patients){
         $scope.arrayOfPatients = patients;
         $scope.patients = self.getPatientObject($scope.arrayOfPatients);

--- a/routes/api/carer.js
+++ b/routes/api/carer.js
@@ -74,17 +74,7 @@
         if (patient) {
           if(patient.carer_id != req.params.carerId){
             patient.updateAttributes({carer_id : (req.params.carerId)}, function(err, updatedPatientData) {
-              carerModel.find((req.params.carerId), function(err, carer) {
-                if(carer){
-                  var patients = carer.patientsIds;
-                  patients.push((req.query.patientId));
-                  carer.updateAttributes({patientsIds:patients}, function(err, updatedCarerData) {
-                    res.status(200).send(updatedCarerData);
-                  });
-                }else {
-                  res.status(404).end();
-                }
-              });
+              res.status(200).send(updatedPatientData);
             });
           } else{
             console.log("Patient already added");


### PR DESCRIPTION
- Fixed some mine faults with refreshing the patient list after adding
  a new

Patient has 1 carer and if a new carer adds patient then the patient
only has the new one
